### PR TITLE
Cargo Publish Dry Run Workflow

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@v2=
+            - uses: actions/checkout@v2
             - uses: dtolnay/rust-toolchain@stable
 
             - name: cargo-release Cache

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,8 +3,7 @@ on:
     push:
         branches: 
             - main
-
-    workflow_dispatch: 
+            - workflows
 
 jobs:
     build_and_publish:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,33 @@
+name: Publish to crates.io (currently only does dry run)
+on:
+    push:
+        branches: 
+            - main
+
+    workflow_dispatch: 
+
+jobs:
+    build_and_publish:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@v2=
+            - uses: dtolnay/rust-toolchain@stable
+
+            - name: cargo-release Cache
+              id: cargo-release-cache
+              uses: actions/cache@v2
+              with:
+                path: ~/.cargo/bin/cargo-release
+                key: ${{ runner.os }}-cargo-release
+
+            - run: cargo install cargo-release
+              if: steps.cargo-release-cache.outputs.cache-hit != 'true'
+
+            - name: cargo Login
+              run: cargo login ${{ secrets.CRATES_IO_API_KEY }}
+
+            - name: cargo Release
+              run: cargo release --dry-run -p multichannel_audio
+
+        

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,12 +1,9 @@
 name: Publish to crates.io (currently only does dry run)
 on:
+    pull_request: {}
     push:
         branches: 
             - main
-    pull_request:
-        branches:
-            - main
-            - workflows
 
 jobs:
     build_and_publish:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -3,6 +3,9 @@ on:
     push:
         branches: 
             - main
+    pull_request:
+        branches:
+            - main
             - workflows
 
 jobs:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -10,21 +10,11 @@ jobs:
         runs-on: ubuntu-latest
         timeout-minutes: 10
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
             - uses: dtolnay/rust-toolchain@stable
 
             - name: Install libasound2-dev
               run: sudo apt-get install libasound2-dev
-
-            # - name: cargo-release Cache
-            #   id: cargo-release-cache
-            #   uses: actions/cache@v2
-            #   with:
-            #     path: ~/.cargo/bin/cargo-release
-            #     key: ${{ runner.os }}-cargo-release
-
-            # - run: cargo install cargo-release
-            #   if: steps.cargo-release-cache.outputs.cache-hit != 'true'
 
             - name: cargo Login
               run: cargo login ${{ secrets.CRATES_IO_API_KEY }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,6 +13,9 @@ jobs:
             - uses: actions/checkout@v2
             - uses: dtolnay/rust-toolchain@stable
 
+            - name: Install libasound2-dev
+              run: sudo apt-get install libasound2-dev
+
             # - name: cargo-release Cache
             #   id: cargo-release-cache
             #   uses: actions/cache@v2

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -13,20 +13,20 @@ jobs:
             - uses: actions/checkout@v2
             - uses: dtolnay/rust-toolchain@stable
 
-            - name: cargo-release Cache
-              id: cargo-release-cache
-              uses: actions/cache@v2
-              with:
-                path: ~/.cargo/bin/cargo-release
-                key: ${{ runner.os }}-cargo-release
+            # - name: cargo-release Cache
+            #   id: cargo-release-cache
+            #   uses: actions/cache@v2
+            #   with:
+            #     path: ~/.cargo/bin/cargo-release
+            #     key: ${{ runner.os }}-cargo-release
 
-            - run: cargo install cargo-release
-              if: steps.cargo-release-cache.outputs.cache-hit != 'true'
+            # - run: cargo install cargo-release
+            #   if: steps.cargo-release-cache.outputs.cache-hit != 'true'
 
             - name: cargo Login
               run: cargo login ${{ secrets.CRATES_IO_API_KEY }}
 
-            - name: cargo Release
-              run: cargo release --dry-run -p multichannel_audio
+            - name: cargo Publish
+              run: cargo publish --dry-run -p multichannel_audio
 
         

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 Cargo.lock
 APIkey.txt
-multichannel_audio_bin/
+multichannel_audio_bin/src/

--- a/multichannel_audio_bin/Cargo.toml
+++ b/multichannel_audio_bin/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "multichannel_audio_bin"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+multichannel_audio = { path = "../multichannel_audio" }
+
+[[bin]]
+name = "multichannel_audio_bin"
+path = "src/main.rs"


### PR DESCRIPTION
Create a basic workflow to do the cargo publish dry run when opening a PR or merging to main. 

In the future, this should publish a new version of the package when pushing to main.