### PR TITLE
Allow audio instance to be cloned

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# PR Name
+
+## Description of Changes
+
+DESCRIPTION GOES HERE
+
+(Include a summary of changes and any issues that are fixed. Include motivation and relevant context).
+
+## How to test this PR
+
+STEPS GO HERE
+
+(Include a step by step process of how to test this PR)
+
+## Relevant Issue(s)
+
+Closes #ISSUE_NUMBER
+
+## Type of Change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update

--- a/multichannel_audio/Cargo.toml
+++ b/multichannel_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multichannel_audio"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.79.0"
 publish = true

--- a/multichannel_audio/src/lib.rs
+++ b/multichannel_audio/src/lib.rs
@@ -2,4 +2,4 @@ pub mod audio_class;
 pub mod methods;
 pub mod missing_device_error;
 pub(crate) mod stream_controller;
-pub mod time_align;
+pub(crate) mod time_align;

--- a/multichannel_audio/src/methods.rs
+++ b/multichannel_audio/src/methods.rs
@@ -11,7 +11,20 @@ use std::sync::Mutex;
 use crate::missing_device_error::MissingDeviceError;
 
 lazy_static! {
+    /// The audio host to use for audio I/O
+    ///
+    /// ## Example:
+    ///
+    /// ```ignore
+    /// cpal::host_from_id(cpal::HostId::Asio).unwrap()
+    /// ```
     pub static ref HOST: Mutex<Option<cpal::Host>> = Mutex::new(None);
+    /// The name of the audio device to use for audio I/O.
+    ///
+    /// ## Example:
+    /// ```ignore
+    /// Focusrite USB ASIO
+    /// ```
     pub static ref DEVICE_NAME: Mutex<String> = Mutex::new(String::new());
 }
 

--- a/multichannel_audio/src/missing_device_error.rs
+++ b/multichannel_audio/src/missing_device_error.rs
@@ -2,6 +2,7 @@ use std::{error::Error, fmt};
 
 use cpal::HostUnavailable;
 
+/// Error type for when the audio device is missing.
 #[derive(Debug)]
 pub enum MissingDeviceError {
     Error(String),

--- a/multichannel_audio/src/stream_controller.rs
+++ b/multichannel_audio/src/stream_controller.rs
@@ -1,10 +1,16 @@
+use std::fmt::Formatter;
 use std::sync::{mpsc, Arc, Mutex};
-use std::thread;
+use std::{fmt, thread};
 
 use cpal::traits::{DeviceTrait, StreamTrait};
 use cpal::{InputCallbackInfo, OutputCallbackInfo, Stream};
 
-pub enum StreamCommand {
+lazy_static::lazy_static!(
+    static ref INPUT_STREAM_STATE: Arc<Mutex<StreamState>> = Arc::new(Mutex::new(StreamState::Stopped));
+    static ref OUTPUT_STREAM_STATE: Arc<Mutex<StreamState>> = Arc::new(Mutex::new(StreamState::Stopped));
+);
+
+pub(crate) enum StreamCommand {
     Play,
     Stop,
 }
@@ -21,9 +27,31 @@ pub enum StreamType {
     },
 }
 
+impl fmt::Debug for StreamType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            StreamType::Input { .. } => write!(f, "Input"),
+            StreamType::Output { .. } => write!(f, "Output"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Copy)]
+pub enum StreamState {
+    Playing,
+    Stopped,
+}
+
 #[derive(Clone)]
 pub(crate) struct StreamController {
     command_sender: mpsc::Sender<StreamCommand>,
+    stream_type: StreamType,
+}
+
+impl Drop for StreamController {
+    fn drop(&mut self) {
+        self.send_command(StreamCommand::Stop);
+    }
 }
 
 impl StreamController {
@@ -31,6 +59,7 @@ impl StreamController {
         let (sender, receiver) = mpsc::channel();
         let config_clone = config.clone(); // Clone output_config
 
+        let stream_type_clone = stream_type.clone();
         thread::spawn(move || {
             let mut stream: Option<Stream> = None; // Initially, there's no stream
 
@@ -81,11 +110,38 @@ impl StreamController {
 
         StreamController {
             command_sender: sender,
+            stream_type: stream_type_clone,
         }
     }
 
     pub fn send_command(&self, command: StreamCommand) {
+        match command {
+            StreamCommand::Play => match self.stream_type {
+                StreamType::Input { .. } => {
+                    *INPUT_STREAM_STATE.lock().unwrap() = StreamState::Playing;
+                }
+                StreamType::Output { .. } => {
+                    *OUTPUT_STREAM_STATE.lock().unwrap() = StreamState::Playing;
+                }
+            },
+            StreamCommand::Stop => match self.stream_type {
+                StreamType::Input { .. } => {
+                    *INPUT_STREAM_STATE.lock().unwrap() = StreamState::Stopped;
+                }
+                StreamType::Output { .. } => {
+                    *OUTPUT_STREAM_STATE.lock().unwrap() = StreamState::Stopped;
+                }
+            },
+        }
+
         self.command_sender.send(command).unwrap();
+    }
+
+    pub fn get_state(&self) -> StreamState {
+        match self.stream_type {
+            StreamType::Input { .. } => *INPUT_STREAM_STATE.lock().unwrap(),
+            StreamType::Output { .. } => *OUTPUT_STREAM_STATE.lock().unwrap(),
+        }
     }
 }
 

--- a/multichannel_audio/src/stream_controller.rs
+++ b/multichannel_audio/src/stream_controller.rs
@@ -15,6 +15,9 @@ pub(crate) enum StreamCommand {
     Stop,
 }
 
+/// The possible types of audio stream.
+///
+/// Input streams are used to record and output streams are used to play audio.
 #[derive(Clone)]
 pub enum StreamType {
     Input {
@@ -36,6 +39,11 @@ impl fmt::Debug for StreamType {
     }
 }
 
+/// The possible states of an audio stream.
+///
+/// Playing means the stream is currently running.
+///
+/// Stopped means the stream is not currently running.
 #[derive(Clone, Debug, PartialEq, Copy)]
 pub enum StreamState {
     Playing,


### PR DESCRIPTION
# Allow audio instance to be cloned

## Description of Changes

Allows the audio instance to be cloned and still play/record as intended. The cloned objects can also be used to play/record. This will allow easier handling of the audio instance in any dependant programs

## How to test this PR

Paste the following contents into multichannel_audio_bin/src/main.rs. It's meant to be used with a 4th generation Focusrite 4i4

```rust
use std::vec;

use multichannel_audio::audio_class;
use multichannel_audio::methods::generate_gaussian_white_noise;
use multichannel_audio::methods::set_host_and_audio_device;

fn main() {
    set_host_and_audio_device().unwrap();

    let fs = 48000;
    let train_duration = 5;

    let mut training_signal = generate_gaussian_white_noise(train_duration as f32, fs, None);
    training_signal.truncate(60000);

    let a = audio_class::AudioInstance::new(fs).unwrap();
    let audio_instance = a.clone();

    let mut quiet_signal = vec![vec![0; 480000]; 6];
    quiet_signal[0] = training_signal[0..48000].to_vec();

    println!("Starting recording");
    let recording: Vec<Vec<i32>> = audio_instance.play_record(quiet_signal.clone()).unwrap();

    quiet_signal[0] = recording[0].clone();

    let _ = match a.play(quiet_signal.clone()) {
        Ok(_) => {}
        Err(e) => {
            println!("Error playing signal: {}", e);
            // break;
        }
    };
}
```

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
